### PR TITLE
chore: add GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,44 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ""
+labels: bug, triage
+assignees: ""
+
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+
+**What were you trying to accomplish?**
+
+## Expected Behavior
+<!--- If you're describing a bug, tell us what should happen -->
+<!--- If you're suggesting a change/improvement, tell us how it should work -->
+
+## Current Behavior
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+1.
+2.
+3.
+4.
+
+## Environment
+
+* **Infrastructure as code technology used**:
+* **(for `cfn-lint`) Python, cfn-lint, and cfn-lint-serverless versions**:
+* **(for `tflint`) Go, tflint versions**:
+* **Debugging logs**
+
+```
+# paste logs here
+```

--- a/.github/ISSUE_TEMPLATE/rule.md
+++ b/.github/ISSUE_TEMPLATE/rule.md
@@ -1,0 +1,24 @@
+---
+name: New Rule
+about: Suggest a new rule
+title: ""
+labels: feature-request, triage
+assignees: ""
+---
+
+## Key information
+
+* Rule PR: (leave this empty)
+* Related issue(s), if known: 
+* Meets the need of 80% of users: (yes/no)
+* Do you need help implementing this rule: (yes/no)
+* Approved by: 
+* Reviewed by: 
+
+## Summary
+
+> One paragraph explaining the proposed rule.
+
+## Rule level
+
+> Explaination for the desired level for this rule. See [the documentation on rules](https://github.com/aws-samples/serverless-rules/blob/main/docs/rules.md) for more information on the rule levels.

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -1,6 +1,16 @@
 Rules
 =====
 
+## Rule levels
+
+A rule can have one of the follow three rule levels: Error, Warning, or Info.
+
+An __Error__ level for a rule means this is a recommended practice for the vast majority of circumstances.
+
+A __Warning__ level means that this is a recommended practice, but you can achieve similar results through a different implementation. For example, you can create alarms through [third party offering](https://aws.amazon.com/lambda/partners/), rather than using AWS CloudWatch.
+
+An __Info__ level means that this does not necessarily align with recommended practices, but can point out potential issues or misconfiguration. For example, an Amazon EventBridge event bus without any rules associated to it, as you might create those rules throught a different template.
+
 ## AWS Lambda
 
 | Level   | Name                                                                | cfn-lint | tflint |


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws-samples/serverless-rules/issues/7

*Description of changes:* Adding GitHub issue templates for common use-cases


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
