### PR TITLE
chore: remove documentation tag on cfn-lint/tflint changes

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -5,5 +5,9 @@ area/tflint:
   - tflint-ruleset-aws-serverless/**
 
 documentation:
-  - docs/**
-  - examples/**
+  - any:
+      - docs/**
+      - examples/**
+    all: 
+      - "!cfn-lint-serverless/**"
+      - "!tflint-ruleset-aws-serverless/**"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Disable automating addition of the __documentation__ tag on PRs that contain changes to the `cfn-lint-serverless` or `tflint-ruleset-aws-serverless` folders.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
