### PR TITLE
feat: lambda EOL runtime rule

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -18,9 +18,9 @@ An __Info__ level means that this does not necessarily align with recommended pr
 | __Warning__ | [Lambda Tracing](lambda.md#tracing)                                 | WS1000   | aws_lambda_function_tracing_rule |
 | __Error__   | [EventSourceMapping Failure Destination](lambda.md#eventsourcemapping-failure-destination) | ES1001   | aws_lambda_event_source_mapping_failure_destination |
 | __Warning__ | [Lambda Permission Multiple Principals](lambda.md#permission-multiple-principals) | WS1002   |_Not implemented_|
-| __Warning__ | [Lambda Star Permissions](lambda.md#star-permissions) | WS1003   |_Not implemented_|
-| __Warning__ | [Lambda Log Retention](lambda.md#log-retention) | WS1004   |_Not implemented_|
-| __Error__   | Lambda Deprecated Runtime                                           |_Not implemented_|_Not implemented_|
+| __Warning__ | [Lambda Star Permissions](lambda.md#star-permissions)               | WS1003   |_Not implemented_|
+| __Warning__ | [Lambda Log Retention](lambda.md#log-retention)                     | WS1004   |_Not implemented_|
+| __Error__   | [Lambda EOL Runtime](lambda.md##nd-of-life-runtime)                 | _E2531_  | aws_lambda_function_eol_runtime |
 | __Error__   | Lambda No Error Alarm                                               |_Not implemented_|_Not implemented_|
 | __Error__   | Async Lambda No Failure Destination                                 |_Not implemented_|_Not implemented_|
 | __Warning__ | Sync Lambda No Duration Alarm                                       |_Not implemented_|_Not implemented_|

--- a/docs/rules/lambda.md
+++ b/docs/rules/lambda.md
@@ -1,6 +1,101 @@
 AWS Lambda Rules
 ================
 
+## End-of-life Runtime
+
+* __Level__: Error
+* __cfn-lint__: E2531
+* __tflint__: aws_lambda_function_eol_runtime
+
+Managed Lambda runtimes for .zip file archives are built around a combination of operating system, programming language, and software libraries that are subject to maintenance and security updates. When security updates are no longer available for a component of a runtime, Lambda deprecates the runtime.
+
+!!! info
+    This rule is implemented natively in `cfn-lint` as rule number __E2531__.
+
+### Implementations
+
+=== "CDK"
+
+    ```typescript
+    import { Code, Function, Runtime } from '@aws-cdk/aws-lambda';
+
+    export class MyStack extends cdk.Stack {
+      constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const myFunction = new Function(
+          scope, 'MyFunction',
+          {
+            code: Code.fromAsset('src/hello/'),
+            handler: 'main.handler',
+            // Select a runtime that is not deprecated
+            runtime: Runtime.PYTHON_3_8,
+          }
+        );
+      }
+    }
+    ```
+
+=== "CloudFormation (JSON)"
+
+    ```json
+    {
+      "Resources": {
+        "MyFunction": {
+          "Type": "AWS::Serverless::Function",
+          "Properties": {
+            "CodeUri": ".",
+            // Select a runtime that is not deprecated
+            "Runtime": "python3.8",
+            "Handler": "main.handler"
+          }
+        }
+      }
+    }
+    ```
+
+=== "CloudFormation (YAML)"
+
+    ```yaml
+    Resources:
+      MyFunction:
+        Type: AWS::Serverless::Function
+        Properties:
+          CodeUri: .
+          # Select a runtime that is not deprecated
+          Runtime: python3.8
+          Handler: main.handler
+    ```
+
+=== "Serverless Framework"
+
+    ```yaml
+    provider:
+      name: aws
+      # Select a runtime that is not deprecated
+      runtime: nodejs14.x
+
+    functions:
+      hello:
+        handler: handler.hello
+    ```
+
+=== "Terraform"
+
+    ```tf
+    resource "aws_lambda_function" "this" {
+      function_name = "my-function"
+      # Select a runtime that is not deprecated
+      runtime       = "python3.8"
+      handler       = "main.handler"
+      filename      = "function.zip"
+    }
+    ```
+
+### See also
+
+* [Runtime support policy](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html)
+
 ## EventSourceMapping Failure Destination
 
 * __Level__: Error

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_function_eol_runtime.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_function_eol_runtime.go
@@ -1,0 +1,83 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// TODO: Write the rule's description here
+// AwsLambdaFunctionEolRuntime checks if the runtime is marked as end-of-life
+type AwsLambdaFunctionEolRuntimeRule struct {
+	resourceType  string
+	attributeName string
+	enum          []string
+}
+
+// NewAwsLambdaFunctionEolRuntimeRule returns new rule with default attributes
+func NewAwsLambdaFunctionEolRuntimeRule() *AwsLambdaFunctionEolRuntimeRule {
+	return &AwsLambdaFunctionEolRuntimeRule{
+		// TODO: Write resource type and attribute name here
+		resourceType:  "aws_lambda_function",
+		attributeName: "runtime",
+		enum: []string{
+			"dotnetcore2.1",
+			"python2.7",
+			"ruby2.5",
+			"nodejs10.x",
+			"nodejs8.10",
+			"nodejs6.10",
+			"nodejs4.3-edge",
+			"nodejs4.3",
+			"nodejs",
+			"dotnetcore2.0",
+			"dotnetcore1.0",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsLambdaFunctionEolRuntimeRule) Name() string {
+	return "aws_lambda_function_eol_runtime"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsLambdaFunctionEolRuntimeRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsLambdaFunctionEolRuntimeRule) Severity() string {
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsLambdaFunctionEolRuntimeRule) Link() string {
+	return ""
+}
+
+// Check checks if the runtime is marked as end-of-life
+func (r *AwsLambdaFunctionEolRuntimeRule) Check(runner tflint.Runner) error {
+	return runner.WalkResourceAttributes(r.resourceType, r.attributeName, func(attribute *hcl.Attribute) error {
+		var val string
+		err := runner.EvaluateExpr(attribute.Expr, &val, nil)
+
+		return runner.EnsureNoError(err, func() error {
+			found := false
+			for _, item := range r.enum {
+				if item == val {
+					found = true
+				}
+			}
+			if found {
+				runner.EmitIssueOnExpr(
+					r,
+					fmt.Sprintf(`"%s" is an end-of-life runtime.`, val),
+					attribute.Expr,
+				)
+			}
+			return nil
+		})
+	})
+}

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_function_eol_runtime_test.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_function_eol_runtime_test.go
@@ -1,0 +1,114 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsLambdaFunctionEolRuntime(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "EOL dotnetcore2.1",
+			Content: `
+resource "aws_lambda_function" "this" {
+  runtime = "dotnetcore2.1"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaFunctionEolRuntimeRule(),
+					Message: "\"dotnetcore2.1\" is an end-of-life runtime.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 28},
+					},
+				},
+			},
+		},
+		{
+			Name: "EOL python2.7",
+			Content: `
+resource "aws_lambda_function" "this" {
+  runtime = "python2.7"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaFunctionEolRuntimeRule(),
+					Message: "\"python2.7\" is an end-of-life runtime.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 24},
+					},
+				},
+			},
+		},
+		{
+			Name: "EOL ruby2.5",
+			Content: `
+resource "aws_lambda_function" "this" {
+  runtime = "ruby2.5"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaFunctionEolRuntimeRule(),
+					Message: "\"ruby2.5\" is an end-of-life runtime.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 22},
+					},
+				},
+			},
+		},
+		{
+			Name: "EOL nodejs10.x",
+			Content: `
+resource "aws_lambda_function" "this" {
+  runtime = "nodejs10.x"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaFunctionEolRuntimeRule(),
+					Message: "\"nodejs10.x\" is an end-of-life runtime.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 3, Column: 13},
+						End:      hcl.Pos{Line: 3, Column: 25},
+					},
+				},
+			},
+		},
+		{
+			Name: "not EOL",
+			Content: `
+resource "aws_lambda_function" "this" {
+  runtime = "python3.8"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsLambdaFunctionEolRuntimeRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add a rule that checks if Lambda functions are marked as deprecated or soon-to-be deprecated in the [Runtime support policy](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
