### PR TITLE
rule: Async Lambda Destination rule

### DIFF
--- a/cfn-lint-serverless/cfn_lint_serverless/rules/__init__.py
+++ b/cfn-lint-serverless/cfn_lint_serverless/rules/__init__.py
@@ -7,6 +7,7 @@ from .api_gateway import (
 from .appsync import AppSyncTracingRule
 from .eventbridge import EventBridgeDLQRule
 from .lambda_ import (
+    LambdaAsyncNoDestinationRule,
     LambdaDefaultMemorySizeRule,
     LambdaDefaultTimeoutRule,
     LambdaESMDestinationRule,
@@ -33,6 +34,7 @@ __all__ = [
     "LambdaTracingRule",
     "LambdaDefaultMemorySizeRule",
     "LambdaDefaultTimeoutRule",
+    "LambdaAsyncNoDestinationRule",
     "SnsNoRedrivePolicyRule",
     "SqsNoRedrivePolicyRule",
     "StepFunctionsTracingRule",

--- a/cfn-lint-serverless/cfn_lint_serverless/rules/lambda_.py
+++ b/cfn-lint-serverless/cfn_lint_serverless/rules/lambda_.py
@@ -5,7 +5,7 @@ Rules for Lambda resources
 
 import re
 from collections import defaultdict
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 from cfnlint.rules import CloudFormationLintRule, RuleMatch
 
@@ -373,6 +373,80 @@ class LambdaDefaultTimeoutRule(CloudFormationLintRule):
             timeout = value.get("Properties", {}).get("Timeout", None)
 
             if timeout is None:
+                matches.append(RuleMatch(["Resources", key], self._message.format(key)))
+
+        return matches
+
+
+class LambdaAsyncNoDestinationRule(CloudFormationLintRule):
+    """
+    Ensure that Lambda functions invoked asynchronously have a destination configured
+    """
+
+    id = "ES1007"  # noqa: VNE003
+    shortdesc = "Lambda Async Destination"
+    description = "Ensure that Lambda functions invoked asynchronously have a destination configured"
+    tags = ["lambda"]
+
+    _message = "Lambda permission {} has an asynchronous permission but doesn't have an EventInvokeConfig resource related to it"  # noqa: E501
+
+    _async_principals = [
+        "events.amazonaws.com",
+        "events.amazonaws.com.cn",
+        "iot.amazonaws.com",
+        "iot.amazonaws.com.cn",
+        "s3.amazonaws.com",
+        "s3.amazonaws.com.cn",
+        "sns.amazonaws.com",
+        "sns.amazonaws.com.cn",
+    ]
+
+    def _get_async_functions(self, permissions: Dict[str, dict]) -> Dict[str, Union[dict, str]]:
+        """
+        Return a list of FunctionName properties for permissions with principals that invoke Lambda
+        functions asynchronously
+        """
+
+        async_functions = {}
+
+        for key, value in permissions.items():
+            function_name = value.get("Properties", {}).get("FunctionName", "")
+            principal = value.get("Properties", {}).get("Principal", "")
+
+            # No FunctionName, we cannot evaluate this rule
+            if not function_name:
+                continue
+
+            if principal in self._async_principals:
+                async_functions[key] = function_name
+
+        return async_functions
+
+    def match(self, cfn):
+        """
+        Match against Lambda functions without an explicity Timeout
+        """
+
+        matches = []
+
+        permissions = cfn.get_resources(["AWS::Lambda::Permission"])
+        event_invoke_configs = cfn.get_resources(["AWS::Lambda::EventInvokeConfig"])
+
+        async_functions = self._get_async_functions(permissions)
+
+        found = []
+
+        for value in event_invoke_configs.values():
+            function_name = value.get("Properties", {}).get("FunctionName", "")
+            on_failure_destination = (
+                value.get("Properties", {}).get("DestinationConfig", {}).get("OnFailure", {}).get("Destination", None)
+            )
+
+            if function_name in async_functions.values() and on_failure_destination is not None:
+                found.append(function_name)
+
+        for key, value in async_functions.items():
+            if value not in found:
                 matches.append(RuleMatch(["Resources", key], self._message.format(key)))
 
         return matches

--- a/cfn-lint-serverless/tests/templates/es1007.fail.yaml
+++ b/cfn-lint-serverless/tests/templates/es1007.fail.yaml
@@ -1,0 +1,74 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+
+Globals:
+  Function:
+    Runtime: python3.8
+    Handler: main.handler
+
+Resources:
+  CloudWatchEventFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        CloudWatchEvent:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              source: ["my-service"]
+
+  EventBridgeRuleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        EventBridgeRule:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source: ["my-service"]
+
+  IoTRuleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        IoTRule:
+          Type: IoTRule
+          Properties:
+            Sql: "SELECT * FROM 'topic/subtopic'"
+
+  S3Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        S3:
+          Type: S3
+          Properties:
+            Bucket: !Ref MyBucket
+            Events: s3:ObjectCreated:*
+
+  ScheduleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: "rate(5 minutes)"
+
+  SNSFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        SNS:
+          Type: SNS
+          Properties:
+            Topic: my-sns-topic
+
+  MyBucket:
+    Type: AWS::S3::Bucket

--- a/cfn-lint-serverless/tests/templates/es1007.pass.yaml
+++ b/cfn-lint-serverless/tests/templates/es1007.pass.yaml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+
+Globals:
+  Function:
+    Runtime: python3.8
+    Handler: main.handler
+    EventInvokeConfig:
+      DestinationConfig:
+        OnFailure:
+          Type: SQS
+
+Resources:
+  CloudWatchEventFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        CloudWatchEvent:
+          Type: CloudWatchEvent
+          Properties:
+            Pattern:
+              source: ["my-service"]
+
+  EventBridgeRuleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        EventBridgeRule:
+          Type: EventBridgeRule
+          Properties:
+            Pattern:
+              source: ["my-service"]
+
+  IoTRuleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        IoTRule:
+          Type: IoTRule
+          Properties:
+            Sql: "SELECT * FROM 'topic/subtopic'"
+
+  S3Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        S3:
+          Type: S3
+          Properties:
+            Bucket: !Ref MyBucket
+            Events: s3:ObjectCreated:*
+
+  ScheduleFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        Schedule:
+          Type: Schedule
+          Properties:
+            Schedule: "rate(5 minutes)"
+
+  SNSFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Events:
+        SNS:
+          Type: SNS
+          Properties:
+            Topic: my-sns-topic
+
+  MyBucket:
+    Type: AWS::S3::Bucket

--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -22,9 +22,9 @@ An __Info__ level means that this does not necessarily align with recommended pr
 | __Warning__ | [Lambda Log Retention](lambda.md#log-retention)                     | WS1004   |_Not implemented_|
 | __Error__   | [Lambda Default Memory Size](lambda.md#default-memory-size)         | ES1005   | aws_lambda_function_default_memory |
 | __Error__   | [Lambda Default Timeout](lambda.md#default-timeout)                 | ES1006   | aws_lambda_function_default_timeout |
+| __Error__   | [Async Lambda Failure Destination](lambda.md#async-failure-destination) | ES1007 |_Not implemented_|
 | __Error__   | [Lambda EOL Runtime](lambda.md#end-of-life-runtime)                 | _E2531_  | aws_lambda_function_eol_runtime |
 | __Error__   | Lambda No Error Alarm                                               |_Not implemented_|_Not implemented_|
-| __Error__   | Async Lambda No Failure Destination                                 |_Not implemented_|_Not implemented_|
 | __Warning__ | Sync Lambda No Duration Alarm                                       |_Not implemented_|_Not implemented_|
 | __Warning__ | Sync Lambda With Destination                                        |_Not implemented_|_Not implemented_|
 | __Error__   | SQS Lambda ReservedConcurrency < 5                                  |_Not implemented_|_Not implemented_|

--- a/docs/rules/lambda.md
+++ b/docs/rules/lambda.md
@@ -2,6 +2,241 @@ AWS Lambda Rules
 ================
 
 
+## Async Failure Destination
+
+* __Level__: Error
+* __cfn-lint__: ES1007
+* __tflint__: _Not implemented_
+
+Several AWS services, such as Amazon S3, Amazon SNS, or Amazon EventBridge, invoke Lambda functions asynchronously to process events. When you invoke a function asynchronously, you don't wait for a response from the function code. You hand off the event to Lambda and Lambda handles the rest.
+
+When an asynchronous calls fail, they should be captured and retried whenever possible. For this purpose, you can set a destination where Lambda will send events for successful or failed invocations.
+
+??? warning "Matching function name between resources"
+
+    This rule works by comparing _Lambda Permission_ resources with _Lambda Event Invoke Config_ resources. For this rule to work correctly, you must set the function name on both resources in the exact same way.
+
+    For example, in CloudFormation, if you use the `Fn::Ref` intrinsic function to refer to your Lambda function on both resources, this rule will work normally. If you use `Fn::Ref` on one, and `Fn::Join` on another, this rule will not work.
+
+    Here are some examples of valid implementation in CloudFormation:
+
+    === "With Fn::Ref"
+
+        ```yaml
+        Resources:
+          Permission:
+            Type: AWS::Lambda::Permission
+            Properties:
+              # Other properties omitted
+              FunctionName: !Ref MyFunction
+
+          EventInvokeConfig:
+            Type: AWS::Lambda::EventInvokeConfig
+            Properties:
+              # Other properties omitted
+              FunctionName: !Ref MyFunction
+        ```
+
+    === "With Fn::Sub"
+
+        ```yaml
+        Resources:
+          Permission:
+            Type: AWS::Lambda::Permission
+            Properties:
+              # Other properties omitted
+              FunctionName: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${MyFunction}"
+
+          EventInvokeConfig:
+            Type: AWS::Lambda::EventInvokeConfig
+            Properties:
+              # Other properties omitted
+              FunctionName: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${MyFunction}"
+        ```
+
+    === "With a static value"
+
+        ```yaml
+        Resources:
+          Permission:
+            Type: AWS::Lambda::Permission
+            Properties:
+              # Other properties omitted
+              FunctionName: my-lambda-function
+
+          EventInvokeConfig:
+            Type: AWS::Lambda::EventInvokeConfig
+            Properties:
+              # Other properties omitted
+              FunctionName: my-lambda-function
+        ```
+
+    By comparison, this implementation will return an error:
+
+    === "With mixed references"
+
+        ```yaml
+        Resources:
+          Permission:
+            Type: AWS::Lambda::Permission
+            Properties:
+              # Other properties omitted
+              FunctionName: !Ref MyFunction
+
+          EventInvokeConfig:
+            Type: AWS::Lambda::EventInvokeConfig
+            Properties:
+              # Other properties omitted
+              FunctionName: my-lambda-function
+        ```
+
+### Implementations
+
+=== "CDK"
+
+    ```typescript
+    import { Code, Function, Runtime } from '@aws-cdk/aws-lambda';
+    import { SnsEventSource } from '@aws-cdk/aws-lambda-event-sources';
+    import { SqsDestination } from '@aws-cdk/aws-lambda-destinations';
+    import { Topic } from '@aws-cdk/aws-sns';
+
+    export class MyStack extends cdk.Stack {
+      constructor(scope: cdk.Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        const myTopic = new Topic(
+          scope, 'MyTopic',
+        );
+
+        const myDLQ = new Queue(
+          scope, 'MyDLQ',
+        );
+
+        const myFunction = new Function(
+          scope, 'MyFunction',
+          {
+            code: Code.fromAsset('src/hello/'),
+            handler: 'main.handler',
+            runtime: Runtime.PYTHON_3_8,
+
+            onFailure: new SqsDestination(myDLQ),
+          }
+        );
+
+        // SNS will trigger the function asynchronously
+        myFunction.addEventSource(new SnsEventSource(myTopic));
+
+
+      }
+    }
+    ```
+
+=== "CloudFormation (JSON)"
+
+    ```json
+    {
+      "Resources": {
+        "SNSFunction": {
+          "Type": "AWS::Serverless::Function",
+          "Properties": {
+            "CodeUri": ".",
+            // SNS will trigger the function asynchronously
+            "Events": {
+              "SNS": {
+                "Type": "SNS",
+                "Properties": {
+                  "Topic": "my-sns-topic"
+                }
+              }
+            },
+            // Configure a failure destination for the function
+            "EventInvokeConfig": {
+              "DestinationConfig": {
+                "OnFailure": {
+                  "Type": "SQS",
+                  "Destination": "arn:aws:sqs:us-east-1:111122223333:my-dlq"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    ```
+
+=== "CloudFormation (YAML)"
+
+    ```yaml
+    SNSFunction:
+      Type: AWS::Serverless::Function
+      Properties:
+        CodeUri: .
+        # SNS will trigger the function asynchronously
+        Events:
+          SNS:
+            Type: SNS
+            Properties:
+              Topic: my-sns-topic
+        # Configure a failure destination for the function
+        EventInvokeConfig:
+          DestinationConfig:
+            OnFailure:
+              Type: SQS
+              Destination: arn:aws:sqs:us-east-1:111122223333:my-dlq
+    ```
+
+=== "Serverless Framework"
+
+    ```yaml
+    functions:
+      hello:
+        handler: main.handler
+        # SNS will trigger the function asynchronously
+        events:
+          - sns:
+              topicName: my-sns-topic
+        # Configure a failure destination for the function
+        destinations:
+          onFailure: arn:aws:sqs:us-east-1:111122223333:my-dlq
+    ```
+
+=== "Terraform"
+
+    ```tf
+    resource "aws_lambda_function" "this" {
+      function_name = "my-function"
+      runtime       = "python3.8"
+      handler       = "main.handler"
+      filename      = "function.zip"
+    }
+
+    resource "aws_lambda_permission" "this" {
+      action        = "lambda:InvokeFunction"
+      function_name = aws_lambda_function.this.function_name
+      # Grants the permission to SNS to invoke this function
+      # SNS will trigger the function asynchronously
+      principal     = "sns.amazonaws.com"
+    }
+
+    resource "aws_lambda_function_event_invoke_config" "example" {
+      function_name = aws_lambda_alias.example.function_name
+
+      # Configure a failure destination for the function
+      destination_config {
+        on_failure {
+          destination = "arn:aws:sqs:us-east-1:111122223333:my-dlq"
+        }
+      }
+    }
+    ```
+
+### See also
+
+* [Asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html)
+* [Serverless Lens: Failure Management](https://docs.aws.amazon.com/wellarchitected/latest/serverless-applications-lens/failure-management.html)
+* [__CloudFormation__: AWS::Lambda::EventInvokeConfig](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-eventinvokeconfig.html)
+* [__Terraform__: aws_lambda_function_event_invoke_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function_event_invoke_config)
+
 ## Default Memory Size
 
 * __Level__: Error
@@ -444,6 +679,65 @@ An AWS Lambda event source mapping reads from streams and poll-based event sourc
 * __tflint__: _Not implemented_
 
 By default, CloudWatch log groups created by Lambda functions have an unlimited retention time. For cost optimization purposes, you should set a retention duration on all log groups. For log archival, export and set cost-effective storage classes that best suit your needs.
+
+??? warning "Referencing the function name in the log group"
+
+    This rule works by matching a Lambda function name in the CloudWatch log group name. For CloudFormation, it supports `Fn::Join`, `Fn::Sub`, and hard-coding the Lambda function name into the log group name.
+
+    Here are some examples of valid implementations:
+
+    === "With Fn::Join"
+    
+        ```yaml
+        Resources:
+          Function:
+            Type: AWS::Serverless::Function
+            Properties:
+              # Omitting other properties
+
+          LogGroup:
+            Type: AWS::Logs::LogGroup
+            Properties:
+              LogGroupName:
+                Fn::Join:
+                - ""
+                - - "/aws/lambda/"
+                  - !Ref Function
+              RetentionInDays: 7
+        ```
+
+    === "With Fn::Sub"
+    
+        ```yaml
+        Resources:
+          Function:
+            Type: AWS::Serverless::Function
+            Properties:
+              # Omitting other properties
+
+          LogGroup:
+            Type: AWS::Logs::LogGroup
+            Properties:
+              LogGroupName: !Sub "/aws/lambda/${Function}"
+              RetentionInDays: 7
+        ```
+
+    === "With function name"
+    
+        ```yaml
+        Resources:
+          Function:
+            Type: AWS::Serverless::Function
+            Properties:
+              # Omitting other properties
+              FunctionName: my_function_name
+
+          LogGroup:
+            Type: AWS::Logs::LogGroup
+            Properties:
+              LogGroupName: "/aws/lambda/my_function_name
+              RetentionInDays: 7
+        ```
 
 ### Why is this a warning?
 

--- a/docs/rules/sns.md
+++ b/docs/rules/sns.md
@@ -24,7 +24,7 @@ You can configure the redrive policy on an Amazon SNS subscription. If SNS canno
 
         // Dead letter queue
         const myDLQ = new Queue(
-          scope, "MyDLQ",
+          scope, 'MyDLQ',
         );
 
         // SNS Topic


### PR DESCRIPTION
## Key information

* Rule issue: N/A
* `cfn-lint` rule ID: ES1007
* `tflint` rule name: 

## Summary

Ensure that Lambda functions that are invoked asynchronously have a destination on failure configured.

## Checklist

* [x] __cfn-lint__: add rule
* [x] __cfn-lint__: add import in `rules/__init__.py`
* [x] __cfn-lint__: add test templates
* [ ] __tflint__: add rule
* [ ] __tflint__: add tests
* [ ] __tflint__: add in `rules/provider.go`
* [x] __docs__: add new section in documentation
* [x] __docs__: add reference in `rules/index.md`