### PR TITLE
feat: add Lambda permission multiple principals rule for tflint

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -17,7 +17,7 @@ An __Info__{: class="badge badge-blue" } level means that this does not necessar
 |:------------------------------------------:|---------------------------------------------------------------------|:--------:|:------:|
 | __Warning__{: class="badge badge-yellow" } | [Lambda Tracing](lambda/tracing.md)                                 | WS1000   | aws_lambda_function_tracing_rule |
 | __Error__{: class="badge badge-red" }      | [EventSourceMapping Failure Destination](lambda/eventsourcemapping_failure_destination.md) | ES1001   | aws_lambda_event_source_mapping_failure_destination |
-| __Warning__{: class="badge badge-yellow" } | [Lambda Permission Multiple Principals](lambda/permission_multiple_principals.md) | WS1002   |_Not implemented_|
+| __Warning__{: class="badge badge-yellow" } | [Lambda Permission Multiple Principals](lambda/permission_multiple_principals.md) | WS1002   | aws_lambda_permission_multiple_principals |
 | __Warning__{: class="badge badge-yellow" } | [Lambda Star Permissions](lambda/star_permissions.md)               | WS1003   |_Not implemented_|
 | __Warning__{: class="badge badge-yellow" } | [Lambda Log Retention](lambda/log_retention.md)                     | WS1004   |_Not implemented_|
 | __Error__{: class="badge badge-red" }      | [Lambda Default Memory Size](lambda/default_memory_size.md)         | ES1005   | aws_lambda_function_default_memory |

--- a/docs/rules/lambda/permission_multiple_principals.md
+++ b/docs/rules/lambda/permission_multiple_principals.md
@@ -9,7 +9,7 @@ __Initial version__: 0.1.3
 __cfn-lint__: WS1002
 {: class="badge" }
 
-__tflint__: _Not implemented_
+__tflint__: aws_lambda_permission_multiple_principals
 {: class="badge" }
 
 You can use resource-based policies to grant permission to other AWS services to invoke your Lambda functions. Different AWS services usually send different payloads to Lambda functions. If multiple services can invoke the same function, this function needs to handle the different types of payload properly, or this could cause unexpected behavior.

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals.go
@@ -1,0 +1,136 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+// AwsLambdaPermissionMultiplePrincipals checks if there are multiple Lambda permission with different principals for a single function
+type AwsLambdaPermissionMultiplePrincipalsRule struct {
+	resourceType string
+	functionName string
+	principal    string
+}
+
+// NewAwsLambdaPermissionMultiplePrincipalsRule returns new rule with default attributes
+func NewAwsLambdaPermissionMultiplePrincipalsRule() *AwsLambdaPermissionMultiplePrincipalsRule {
+	return &AwsLambdaPermissionMultiplePrincipalsRule{
+		resourceType: "aws_lambda_permission",
+		functionName: "function_name",
+		principal:    "principal",
+	}
+}
+
+// Name returns the rule name
+func (r *AwsLambdaPermissionMultiplePrincipalsRule) Name() string {
+	return "aws_lambda_permission_multiple_principals"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsLambdaPermissionMultiplePrincipalsRule) Enabled() bool {
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsLambdaPermissionMultiplePrincipalsRule) Severity() string {
+	return tflint.WARNING
+}
+
+// Link returns the rule reference link
+func (r *AwsLambdaPermissionMultiplePrincipalsRule) Link() string {
+	return "https://awslabs.github.io/serverless-rules/rules/lambda/permission_multiple_principals/"
+}
+
+// Check checks if there are multiple Lambda permission with different principals for a single function
+func (r *AwsLambdaPermissionMultiplePrincipalsRule) Check(runner tflint.Runner) error {
+	permissions := make(map[string]map[string][]hcl.Expression)
+
+	err := runner.WalkResources(r.resourceType, func(resource *configs.Resource) error {
+		// Attribute
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: r.principal,
+				},
+				{
+					Name: r.functionName,
+				},
+			},
+		})
+
+		if diags.HasErrors() {
+			return diags
+		}
+
+		// Get attribute value
+		var principalVal string
+		principal, ok := body.Attributes[r.principal]
+		if !ok {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.principal),
+				body.MissingItemRange,
+			)
+
+			return nil
+		}
+		err := runner.EvaluateExpr(principal.Expr, &principalVal, nil)
+		if err != nil {
+			return err
+		}
+
+		// Get reference attribute value
+		var functionNameVal string
+		functionName, ok := body.Attributes[r.functionName]
+		if !ok {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.functionName),
+				body.MissingItemRange,
+			)
+
+			return nil
+		}
+		err = runner.EvaluateExpr(functionName.Expr, &functionNameVal, nil)
+		if err != nil {
+			return err
+		}
+
+		if _, ok = permissions[functionNameVal]; !ok {
+			permissions[functionNameVal] = make(map[string][]hcl.Expression)
+		}
+
+		permissions[functionNameVal][principalVal] = append(permissions[functionNameVal][principalVal], principal.Expr)
+
+		// if principalVal != "true" {
+		// 	runner.EmitIssueOnExpr(
+		// 		r,
+		// 		fmt.Sprintf("\"%s\" should be set to true.", r.principal),
+		// 		principal.Expr,
+		// 	)
+		// }
+
+		return nil
+	})
+
+	// Parse permissions
+	for _, fnPermissions := range permissions {
+		// More than one principal type for a given functionName
+		if len(fnPermissions) > 1 {
+			for _, exprs := range fnPermissions {
+				for _, expr := range exprs {
+					runner.EmitIssueOnExpr(
+						r,
+						fmt.Sprintf("different \"%s\" values for the same %s.", r.principal, r.functionName),
+						expr,
+					)
+				}
+			}
+		}
+	}
+
+	return err
+}

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
@@ -61,6 +61,68 @@ resource "aws_lambda_permission" "b" {
 }
 
 resource "aws_lambda_permission" "c" {
+	function_name = "my-function"
+	principal = "apigateway.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "d" {
+	function_name = "my-function"
+	principal = "sqs.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 14},
+						End:      hcl.Pos{Line: 4, Column: 36},
+					},
+				},
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 9, Column: 14},
+						End:      hcl.Pos{Line: 9, Column: 33},
+					},
+				},
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 14, Column: 14},
+						End:      hcl.Pos{Line: 14, Column: 40},
+					},
+				},
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 19, Column: 14},
+						End:      hcl.Pos{Line: 19, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple principals",
+			Content: `
+resource "aws_lambda_permission" "a" {
+	function_name = "my-function"
+	principal = "events.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "b" {
+	function_name = "my-function"
+	principal = "sns.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "c" {
 	function_name = "my-function-c"
 	principal = "sns.amazonaws.com"
 }

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
@@ -1,6 +1,8 @@
 package rules
 
 import (
+	"fmt"
+	"sort"
 	"testing"
 
 	hcl "github.com/hashicorp/hcl/v2"
@@ -188,6 +190,52 @@ resource "aws_lambda_permission" "b" {
 		if err := rule.Check(runner); err != nil {
 			t.Fatalf("Unexpected error occurred: %s", err)
 		}
+
+		sort.Slice(tc.Expected, func(i, j int) bool {
+			vi, vj := tc.Expected[i], tc.Expected[j]
+			if vi.Rule.Name() != vj.Rule.Name() {
+				return vi.Rule.Name() < vj.Rule.Name()
+			} else if vi.Message != vj.Message {
+				return vi.Message < vj.Message
+			} else if vi.Range.Filename != vj.Range.Filename {
+				return vi.Range.Filename < vj.Range.Filename
+			} else if vi.Range.Start.Line != vj.Range.Start.Line {
+				return vi.Range.Start.Line < vj.Range.Start.Line
+			} else if vi.Range.Start.Column != vj.Range.Start.Column {
+				return vi.Range.Start.Column < vj.Range.Start.Column
+			} else if vi.Range.End.Line != vj.Range.End.Line {
+				return vi.Range.End.Line < vj.Range.End.Line
+			} else if vi.Range.End.Column != vj.Range.End.Column {
+				return vi.Range.End.Column < vj.Range.End.Column
+			} else {
+				return false
+			}
+
+		})
+		sort.Slice(runner.Issues, func(i, j int) bool {
+			vi, vj := runner.Issues[i], runner.Issues[j]
+			if vi.Rule.Name() != vj.Rule.Name() {
+				return vi.Rule.Name() < vj.Rule.Name()
+			} else if vi.Message != vj.Message {
+				return vi.Message < vj.Message
+			} else if vi.Range.Filename != vj.Range.Filename {
+				return vi.Range.Filename < vj.Range.Filename
+			} else if vi.Range.Start.Line != vj.Range.Start.Line {
+				return vi.Range.Start.Line < vj.Range.Start.Line
+			} else if vi.Range.Start.Column != vj.Range.Start.Column {
+				return vi.Range.Start.Column < vj.Range.Start.Column
+			} else if vi.Range.End.Line != vj.Range.End.Line {
+				return vi.Range.End.Line < vj.Range.End.Line
+			} else if vi.Range.End.Column != vj.Range.End.Column {
+				return vi.Range.End.Column < vj.Range.End.Column
+			} else {
+				return false
+			}
+
+		})
+
+		fmt.Printf("%+v\n", tc.Expected)
+		fmt.Printf("%+v\n", runner.Issues)
 
 		helper.AssertIssues(t, tc.Expected, runner.Issues)
 	}

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
@@ -1,0 +1,132 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsLambdaPermissionMultiplePrincipals(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "multiple principals",
+			Content: `
+resource "aws_lambda_permission" "a" {
+	function_name = "my-function"
+	principal = "events.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "b" {
+	function_name = "my-function"
+	principal = "sns.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 14},
+						End:      hcl.Pos{Line: 4, Column: 36},
+					},
+				},
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 9, Column: 14},
+						End:      hcl.Pos{Line: 9, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple principals",
+			Content: `
+resource "aws_lambda_permission" "a" {
+	function_name = "my-function"
+	principal = "events.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "b" {
+	function_name = "my-function"
+	principal = "sns.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "c" {
+	function_name = "my-function-c"
+	principal = "sns.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 14},
+						End:      hcl.Pos{Line: 4, Column: 36},
+					},
+				},
+				{
+					Rule:    NewAwsLambdaPermissionMultiplePrincipalsRule(),
+					Message: `different "principal" values for the same function_name.`,
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 9, Column: 14},
+						End:      hcl.Pos{Line: 9, Column: 33},
+					},
+				},
+			},
+		},
+		{
+			Name: "multiple principals",
+			Content: `
+resource "aws_lambda_permission" "a" {
+	function_name = "my-function"
+	principal = "events.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "b" {
+	function_name = "my-function"
+	principal = "events.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "multiple principals",
+			Content: `
+resource "aws_lambda_permission" "a" {
+	function_name = "my-function-a"
+	principal = "events.amazonaws.com"
+}
+
+resource "aws_lambda_permission" "b" {
+	function_name = "my-function-b"
+	principal = "sns.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsLambdaPermissionMultiplePrincipalsRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/tflint-ruleset-aws-serverless/rules/provider.go
+++ b/tflint-ruleset-aws-serverless/rules/provider.go
@@ -19,6 +19,7 @@ var Rules = []tflint.Rule{
 	NewAwsLambdaFunctionTracingRule(),
 	NewAwsLambdaFunctionDefaultMemoryRule(),
 	NewAwsLambdaFunctionDefaultTimeoutRule(),
+	NewAwsLambdaPermissionMultiplePrincipalsRule(),
 	NewAwsSfnStateMachineTracingRule(),
 	NewAwsSnsTopicSubscriptionRedrivePolicyRule(),
 	NewAwsSqsQueueRedrivePolicyRule(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add [Lambda Permission Multiple Principals](https://awslabs.github.io/serverless-rules/rules/lambda/permission_multiple_principals/) rule for tflint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
