### PR TITLE
feat: add Lambda async failure destination rule for tflint

### DIFF
--- a/docs/rules/index.md
+++ b/docs/rules/index.md
@@ -22,7 +22,7 @@ An __Info__{: class="badge badge-blue" } level means that this does not necessar
 | __Warning__{: class="badge badge-yellow" } | [Lambda Log Retention](lambda/log_retention.md)                     | WS1004   |_Not implemented_|
 | __Error__{: class="badge badge-red" }      | [Lambda Default Memory Size](lambda/default_memory_size.md)         | ES1005   | aws_lambda_function_default_memory |
 | __Error__{: class="badge badge-red" }      | [Lambda Default Timeout](lambda/default_timeout.md)                 | ES1006   | aws_lambda_function_default_timeout |
-| __Error__{: class="badge badge-red" }      | [Async Lambda Failure Destination](lambda/async_failure_destination.md) | ES1007 |_Not implemented_|
+| __Error__{: class="badge badge-red" }      | [Async Lambda Failure Destination](lambda/async_failure_destination.md) | ES1007 | aws_lambda_event_invoke_config_async_on_failure |
 | __Error__{: class="badge badge-red" }      | [Lambda EOL Runtime](lambda/end_of_life_runtime.md)                 | _E2531_  | aws_lambda_function_eol_runtime |
 
 ## Amazon API Gateway REST APIs

--- a/docs/rules/lambda/async_failure_destination.md
+++ b/docs/rules/lambda/async_failure_destination.md
@@ -9,7 +9,7 @@ __Initial version__: 0.1.8
 __cfn-lint__: ES1007
 {: class="badge" }
 
-__tflint__: _Not implemented_
+__tflint__: aws_lambda_event_invoke_config_async_on_failure
 {: class="badge" }
 
 Several AWS services, such as Amazon S3, Amazon SNS, or Amazon EventBridge, invoke Lambda functions asynchronously to process events. When you invoke a function asynchronously, you don't wait for a response from the function code. You hand off the event to Lambda and Lambda handles the rest.

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_event_invoke_config_async_on_failure.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_event_invoke_config_async_on_failure.go
@@ -1,0 +1,282 @@
+package rules
+
+import (
+	"fmt"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/terraform/configs"
+	"github.com/terraform-linters/tflint-plugin-sdk/tflint"
+)
+
+type AsyncPermission struct {
+	functionName string
+	found        bool
+	expression   hcl.Expression
+}
+
+// AwsLambdaEventInvokeConfigAsyncOnFailure checks if an event invoke config has a destination on failure if the function has permission for an async principal
+type AwsLambdaEventInvokeConfigAsyncOnFailureRule struct {
+	permissionType        string
+	eventInvokeConfigType string
+	functionName          string
+	principal             string
+	block1Name            string
+	block2Name            string
+	attributeName         string
+	enumPrincipal         []string
+}
+
+// NewAwsLambdaEventInvokeConfigAsyncOnFailureRule returns new rule with default attributes
+func NewAwsLambdaEventInvokeConfigAsyncOnFailureRule() *AwsLambdaEventInvokeConfigAsyncOnFailureRule {
+	return &AwsLambdaEventInvokeConfigAsyncOnFailureRule{
+		permissionType:        "aws_lambda_permission",
+		eventInvokeConfigType: "aws_lambda_function_event_invoke_config",
+		functionName:          "function_name",
+		principal:             "principal",
+		block1Name:            "destination_config",
+		block2Name:            "on_failure",
+		attributeName:         "destination",
+		enumPrincipal: []string{
+			"events.amazonaws.com",
+			"events.amazonaws.com.cn",
+			"iot.amazonaws.com",
+			"iot.amazonaws.com.cn",
+			"s3.amazonaws.com",
+			"s3.amazonaws.com.cn",
+			"sns.amazonaws.com",
+			"sns.amazonaws.com.cn",
+		},
+	}
+}
+
+// Name returns the rule name
+func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Name() string {
+	return "aws_lambda_event_invoke_config_async_on_failure"
+}
+
+// Enabled returns whether the rule is enabled by default
+func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Enabled() bool {
+	// TODO: Determine whether the rule is enabled by default
+	return true
+}
+
+// Severity returns the rule severity
+func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Severity() string {
+	// TODO: Determine the rule's severiry
+	return tflint.ERROR
+}
+
+// Link returns the rule reference link
+func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Link() string {
+	return "https://awslabs.github.io/serverless-rules/rules/lambda/async_failure_destination/"
+}
+
+// Check checks if an event invoke config has a destination on failure if the function has permission for an async principal
+func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Check(runner tflint.Runner) error {
+	var asyncPerms []AsyncPermission
+
+	// Scan permissions
+	err := runner.WalkResources(r.permissionType, func(resource *configs.Resource) error {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: r.functionName,
+				},
+				{
+					Name: r.principal,
+				},
+			},
+		})
+
+		if diags.HasErrors() {
+			return diags
+		}
+
+		// Get the permission principal
+		var principalVal string
+		principal, ok := body.Attributes[r.principal]
+		if !ok {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.attributeName),
+				body.MissingItemRange,
+			)
+			return nil
+		}
+		err := runner.EvaluateExpr(principal.Expr, &principalVal, nil)
+		if err != nil {
+			return err
+		}
+
+		// Check if the permission is for a principal that invokes the function asynchronously
+		isAsync := false
+		for _, asyncPrincipal := range r.enumPrincipal {
+			if principalVal == asyncPrincipal {
+				isAsync = true
+				break
+			}
+		}
+		// Permission is not async, break early
+		if !isAsync {
+			return nil
+		}
+
+		// Get the function name
+		var functionNameVal string
+		functionName, ok := body.Attributes[r.functionName]
+		if !ok {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.attributeName),
+				body.MissingItemRange,
+			)
+			return nil
+		}
+		err = runner.EvaluateExpr(functionName.Expr, &functionNameVal, nil)
+		if err != nil {
+			return err
+		}
+
+		// Add the function name to the list of async functions
+		asyncPerms = append(asyncPerms, AsyncPermission{
+			functionName: functionNameVal,
+			found:        false,
+			expression:   functionName.Expr,
+		})
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	// Scan Event Invoke Config
+	err = runner.WalkResources(r.eventInvokeConfigType, func(resource *configs.Resource) error {
+		body, _, diags := resource.Config.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: r.functionName,
+				},
+			},
+			Blocks: []hcl.BlockHeaderSchema{
+				{
+					Type: r.block1Name,
+				},
+			},
+		})
+
+		if diags.HasErrors() {
+			return diags
+		}
+
+		// Get the function name
+		var functionNameVal string
+		functionName, ok := body.Attributes[r.functionName]
+		if !ok {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.attributeName),
+				body.MissingItemRange,
+			)
+			return nil
+		}
+		err = runner.EvaluateExpr(functionName.Expr, &functionNameVal, nil)
+		if err != nil {
+			return err
+		}
+
+		// Check if the function is async
+		isAsync := false
+		for pos := range asyncPerms {
+			if functionNameVal == asyncPerms[pos].functionName {
+				asyncPerms[pos].found = true
+				isAsync = true
+				break
+			}
+		}
+
+		// Function is not async, break early
+		if !isAsync {
+			return nil
+		}
+
+		// Check for block level 1
+		blocks := body.Blocks.OfType(r.block1Name)
+		if len(blocks) != 1 {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.block1Name),
+				body.MissingItemRange,
+			)
+
+			return nil
+		}
+
+		// Check for block level 2
+		body, _, diags = blocks[0].Body.PartialContent(&hcl.BodySchema{
+			Blocks: []hcl.BlockHeaderSchema{
+				{
+					Type: r.block2Name,
+				},
+			},
+		})
+
+		if diags.HasErrors() {
+			return diags
+		}
+
+		blocks = body.Blocks.OfType(r.block2Name)
+		if len(blocks) != 1 {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.block2Name),
+				body.MissingItemRange,
+			)
+
+			return nil
+		}
+
+		// Check for attribute in block
+		body, _, diags = blocks[0].Body.PartialContent(&hcl.BodySchema{
+			Attributes: []hcl.AttributeSchema{
+				{
+					Name: r.attributeName,
+				},
+			},
+		})
+
+		if diags.HasErrors() {
+			return diags
+		}
+
+		if _, ok = body.Attributes[r.attributeName]; !ok {
+			runner.EmitIssue(
+				r,
+				fmt.Sprintf("\"%s\" is not present.", r.attributeName),
+				body.MissingItemRange,
+			)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%+v\n", asyncPerms)
+
+	// Scan for missing Event Invoke Config.
+	for _, asyncPerm := range asyncPerms {
+		if !asyncPerm.found {
+			runner.EmitIssueOnExpr(
+				r,
+				fmt.Sprintf("missing \"%s\" resource for %s.", r.eventInvokeConfigType, r.functionName),
+				asyncPerm.expression,
+			)
+		}
+	}
+
+	return nil
+}

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_event_invoke_config_async_on_failure_test.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_event_invoke_config_async_on_failure_test.go
@@ -1,0 +1,178 @@
+package rules
+
+import (
+	"testing"
+
+	hcl "github.com/hashicorp/hcl/v2"
+	"github.com/terraform-linters/tflint-plugin-sdk/helper"
+)
+
+func Test_AwsLambdaEventInvokeConfigAsyncOnFailure(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Content  string
+		Expected helper.Issues
+	}{
+		{
+			Name: "missing aws_lambda_function_event_invoke_config",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "sns.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaEventInvokeConfigAsyncOnFailureRule(),
+					Message: "missing \"aws_lambda_function_event_invoke_config\" resource for function_name.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 4, Column: 18},
+						End:      hcl.Pos{Line: 4, Column: 38},
+					},
+				},
+			},
+		},
+		{
+			Name: "missing destination_config",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "sns.amazonaws.com"
+}
+
+resource "aws_lambda_function_event_invoke_config" "example" {
+	function_name = "my-lambda-function"
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaEventInvokeConfigAsyncOnFailureRule(),
+					Message: "\"destination_config\" is not present.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 8, Column: 62},
+						End:      hcl.Pos{Line: 8, Column: 62},
+					},
+				},
+			},
+		},
+		{
+			Name: "missing on_failure",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "sns.amazonaws.com"
+}
+
+resource "aws_lambda_function_event_invoke_config" "example" {
+	function_name = "my-lambda-function"
+
+	destination_config {}
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaEventInvokeConfigAsyncOnFailureRule(),
+					Message: "\"on_failure\" is not present.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 11, Column: 21},
+						End:      hcl.Pos{Line: 11, Column: 21},
+					},
+				},
+			},
+		},
+		{
+			Name: "missing destination",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "sns.amazonaws.com"
+}
+
+resource "aws_lambda_function_event_invoke_config" "example" {
+	function_name = "my-lambda-function"
+
+	destination_config {
+		on_failure {}
+	}
+}
+`,
+			Expected: helper.Issues{
+				{
+					Rule:    NewAwsLambdaEventInvokeConfigAsyncOnFailureRule(),
+					Message: "\"destination\" is not present.",
+					Range: hcl.Range{
+						Filename: "resource.tf",
+						Start:    hcl.Pos{Line: 12, Column: 14},
+						End:      hcl.Pos{Line: 12, Column: 14},
+					},
+				},
+			},
+		},
+		{
+			Name: "valid",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "sns.amazonaws.com"
+}
+
+resource "aws_lambda_function_event_invoke_config" "example" {
+	function_name = "my-lambda-function"
+
+	destination_config {
+		on_failure {
+			destination = "arn:aws:sqs:us-east-1:111122223333:my-dlq"
+		}
+	}
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "valid no async no event invoke config",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "apigateway.amazonaws.com"
+}
+`,
+			Expected: helper.Issues{},
+		},
+		{
+			Name: "valid no async",
+			Content: `
+resource "aws_lambda_permission" "this" {
+	action        = "lambda:InvokeFunction"
+	function_name = "my-lambda-function"
+	principal     = "apigateway.amazonaws.com"
+}
+
+resource "aws_lambda_function_event_invoke_config" "example" {
+	function_name = "my-lambda-function"
+}
+`,
+			Expected: helper.Issues{},
+		},
+	}
+
+	rule := NewAwsLambdaEventInvokeConfigAsyncOnFailureRule()
+
+	for _, tc := range cases {
+		runner := helper.TestRunner(t, map[string]string{"resource.tf": tc.Content})
+
+		if err := rule.Check(runner); err != nil {
+			t.Fatalf("Unexpected error occurred: %s", err)
+		}
+
+		helper.AssertIssues(t, tc.Expected, runner.Issues)
+	}
+}

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals.go
@@ -105,14 +105,6 @@ func (r *AwsLambdaPermissionMultiplePrincipalsRule) Check(runner tflint.Runner) 
 
 		permissions[functionNameVal][principalVal] = append(permissions[functionNameVal][principalVal], principal.Expr)
 
-		// if principalVal != "true" {
-		// 	runner.EmitIssueOnExpr(
-		// 		r,
-		// 		fmt.Sprintf("\"%s\" should be set to true.", r.principal),
-		// 		principal.Expr,
-		// 	)
-		// }
-
 		return nil
 	})
 

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_permission_multiple_principals_test.go
@@ -1,7 +1,6 @@
 package rules
 
 import (
-	"fmt"
 	"sort"
 	"testing"
 
@@ -233,9 +232,6 @@ resource "aws_lambda_permission" "b" {
 			}
 
 		})
-
-		fmt.Printf("%+v\n", tc.Expected)
-		fmt.Printf("%+v\n", runner.Issues)
 
 		helper.AssertIssues(t, tc.Expected, runner.Issues)
 	}

--- a/tflint-ruleset-aws-serverless/rules/provider.go
+++ b/tflint-ruleset-aws-serverless/rules/provider.go
@@ -20,6 +20,7 @@ var Rules = []tflint.Rule{
 	NewAwsLambdaFunctionDefaultMemoryRule(),
 	NewAwsLambdaFunctionDefaultTimeoutRule(),
 	NewAwsLambdaPermissionMultiplePrincipalsRule(),
+	NewAwsLambdaEventInvokeConfigAsyncOnFailureRule(),
 	NewAwsSfnStateMachineTracingRule(),
 	NewAwsSnsTopicSubscriptionRedrivePolicyRule(),
 	NewAwsSqsQueueRedrivePolicyRule(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add [Lambda Async Failure Destination](https://awslabs.github.io/serverless-rules/rules/lambda/async_failure_destination/) rule for tflint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
