### PR TITLE
fix(cfnlint): support variables in Sub for WS1004, fixes #62

### DIFF
--- a/cfn-lint-serverless/tests/templates/ws1004-sub-vars-hardcoded.pass.yaml
+++ b/cfn-lint-serverless/tests/templates/ws1004-sub-vars-hardcoded.pass.yaml
@@ -1,0 +1,21 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: my-function-name
+      CodeUri: .
+      Runtime: python3.8
+      Handler: main.handler
+      Tracing: Active
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - "/aws/lambda/${Fn}"
+        - Fn: my-function-name
+
+      RetentionInDays: 7

--- a/cfn-lint-serverless/tests/templates/ws1004-sub-vars.pass.yaml
+++ b/cfn-lint-serverless/tests/templates/ws1004-sub-vars.pass.yaml
@@ -1,0 +1,20 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+
+Resources:
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: .
+      Runtime: python3.8
+      Handler: main.handler
+      Tracing: Active
+
+  LogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub
+        - "/aws/lambda/${Fn}"
+        - Fn: !Ref Function
+
+      RetentionInDays: 7


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/serverless-rules/issues/62

*Description of changes:*

Add support for `!Sub` with variables for rule WS1004 in cfn-lint.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
