### PR TITLE
fix(cfn-lint): ignore ES6000 for DLQs, fixes #79

### DIFF
--- a/cfn-lint-serverless/tests/templates/es6000-multiple.pass.yaml
+++ b/cfn-lint-serverless/tests/templates/es6000-multiple.pass.yaml
@@ -1,0 +1,15 @@
+# Test for https://github.com/awslabs/serverless-rules/issues/79
+AWSTemplateFormatVersion: "2010-09-09"
+
+Resources:
+  Queue:
+    Type: AWS::SQS::Queue
+    Properties:
+      RedrivePolicy: !Sub |
+        {
+          "deadLetterTargetArn": "${DLQ}",
+          "maxReceiveCount": 4
+        }
+
+  DLQ:
+    Type: AWS::SQS::Queue


### PR DESCRIPTION
*Issue #, if available:* #79

*Description of changes:*

* Disable checking for redrive policies on SQS queues used as DLQs

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
