### PR TITLE
feat(tflint): disable cross-resource rules

### DIFF
--- a/docs/rules/lambda/async_failure_destination.md
+++ b/docs/rules/lambda/async_failure_destination.md
@@ -94,6 +94,10 @@ When an asynchronous calls fail, they should be captured and retried whenever po
               FunctionName: my-lambda-function
         ```
 
+??? bug "Disabled for Terraform"
+
+    This rule is disabled for Terraform, as the current linter only support static values in expressions. See [this issue](https://github.com/awslabs/serverless-rules/issues/107) for more information.
+
 ## Implementations
 
 === "CDK"

--- a/docs/rules/lambda/log_retention.md
+++ b/docs/rules/lambda/log_retention.md
@@ -73,6 +73,10 @@ By default, CloudWatch log groups created by Lambda functions have an unlimited 
               RetentionInDays: 7
         ```
 
+??? bug "Disabled for Terraform"
+
+    This rule is disabled for Terraform, as the current linter only support static values in expressions. See [this issue](https://github.com/awslabs/serverless-rules/issues/107) for more information.
+
 ## Why is this a warning?
 
 Since `serverless-rules` evaluate infrastructure-as-code template, it cannot check if you use a solution that will automatically change the configuration of log groups after the fact.

--- a/docs/rules/sqs/redrive_policy.md
+++ b/docs/rules/sqs/redrive_policy.md
@@ -14,6 +14,10 @@ __tflint__: aws_sqs_queue_redrive_policy
 
 You can configure the redrive policy on an Amazon SQS queue. With a redrive policy, you can define how many times SQS will make the messages available for consumers. After that, SQS will send it to the dead-letter queue specified in the policy.
 
+??? bug "Disabled for Terraform"
+
+    This rule is disabled for Terraform, as the current linter only support static values in expressions. See [this issue](https://github.com/awslabs/serverless-rules/issues/107) for more information.
+
 ## Implementations
 
 === "CDK"

--- a/tflint-ruleset-aws-serverless/rules/aws_cloudwatch_log_group_lambda_retention.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_cloudwatch_log_group_lambda_retention.go
@@ -43,7 +43,7 @@ func (r *AwsCloudwatchLogGroupLambdaRetentionRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *AwsCloudwatchLogGroupLambdaRetentionRule) Enabled() bool {
-	return true
+	return false
 }
 
 // Severity returns the rule severity

--- a/tflint-ruleset-aws-serverless/rules/aws_lambda_event_invoke_config_async_on_failure.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_lambda_event_invoke_config_async_on_failure.go
@@ -57,7 +57,7 @@ func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Name() string {
 // Enabled returns whether the rule is enabled by default
 func (r *AwsLambdaEventInvokeConfigAsyncOnFailureRule) Enabled() bool {
 	// TODO: Determine whether the rule is enabled by default
-	return true
+	return false
 }
 
 // Severity returns the rule severity

--- a/tflint-ruleset-aws-serverless/rules/aws_sqs_queue_redrive_policy.go
+++ b/tflint-ruleset-aws-serverless/rules/aws_sqs_queue_redrive_policy.go
@@ -29,7 +29,7 @@ func (r *AwsSqsQueueRedrivePolicyRule) Name() string {
 
 // Enabled returns whether the rule is enabled by default
 func (r *AwsSqsQueueRedrivePolicyRule) Enabled() bool {
-	return true
+	return false
 }
 
 // Severity returns the rule severity


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/serverless-rules/issues/107

*Description of changes:*

Disable rules that require comparing the values of multiple, related resources. See https://github.com/awslabs/serverless-rules/issues/107 for more details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
