### PR TITLE
chore(cfn-lint): cfn-lint dependencies version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
         os:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}

--- a/cfn-lint-serverless/pyproject.toml
+++ b/cfn-lint-serverless/pyproject.toml
@@ -8,7 +8,7 @@ license = "MIT-0"
 
 [tool.poetry.dependencies]
 python = "^3.6"
-cfn-lint = ">=0.49.2,<0.55.0"
+cfn-lint = ">=0.49.2,<1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/serverless-rules/issues/94

*Description of changes:*

Allow newer versions of cfn-lint without releasing a new version of cfn-lint-serverless.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
