### PR TITLE
fix: upgrade mkdocs-material to >=9.5.32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+mkdocs-material>=9.5.32


### PR DESCRIPTION
Adds requirements.txt pinning mkdocs-material to >=9.5.32 which includes security improvements.

The mkdocs-deploy-gh-pages action will read this file during doc builds.

No functional changes to documentation content or search functionality.