### PR TITLE
fix: pin MkDocs to <2.0 to prevent Material incompatibility

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
-mkdocs
+mkdocs<2.0
 mkdocs-material

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 mkdocs-material>=9.5.32
+mkdocs<2.0


### PR DESCRIPTION
## Summary

Prevents automatic upgrades to MkDocs 2.0 (in pre-release) which is incompatible with Material for MkDocs.

## Problem

MkDocs 2.0 will be incompatible with Material for MkDocs due to:
- Removal of the plugin system
- Complete rewrite of theming with pre-rendered HTML
- New TOML configuration format

The project pins `mkdocs-material>=9.5.32` but doesn't constrain MkDocs itself. When MkDocs 2.0 releases to PyPI, documentation builds will break.

## Solution

Add `mkdocs<2.0` constraint to both `requirements.txt` and `requirements-dev.txt`:
- Blocks automatic upgrade to incompatible version 2.0
- Allows security patches and minor updates within 1.x
- Ensures CI and local dev use same MkDocs version

## Testing

- ✅ Installed dependencies in clean virtualenv
- ✅ Verified MkDocs 1.6.1 installed (not 2.x)
- ✅ Documentation builds successfully
- ✅ Both requirements files install same version

## References

- Material for MkDocs blog post: https://squidfunk.github.io/mkdocs-material/blog/2026/02/18/mkdocs-2.0/
- Material team recommends eventual migration to Zensical

This buys time to evaluate long-term options without forcing an immediate decision when MkDocs 2.0 drops.