### PR TITLE
Upgrade Material for MkDocs to 9.7.2 with modern theme

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -11,6 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
+        uses: mhausenblas/mkdocs-deploy-gh-pages@1.26
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUIREMENTS: requirements.txt

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,13 +17,34 @@ nav:
 theme:
   name: material
   palette:
-    scheme: default
-    primary: teal
-    accent: deep orange
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
   logo: images/aws-logo-light.svg
   favicon: images/aws-logo-light.svg
   features:
     - navigation.sections
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.path
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - header.autohide
+    - search.suggest
+    - search.highlight
+    - content.code.copy
 
 plugins:
   - search
@@ -35,11 +56,12 @@ markdown_extensions:
   - pymdownx.highlight:
       linenums: true
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - toc:
       permalink: true
 
 extra_css:
   - stylesheets/extra.css
 
-copyright: Copyright &copy; 2021 Amazon Web Services
+copyright: Copyright &copy; 2026 Amazon Web Services

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 mkdocs<2.0
-mkdocs-material
+mkdocs-material>=9.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mkdocs-material>=9.5.32
+mkdocs-material>=9.7.2
 mkdocs<2.0


### PR DESCRIPTION
## Summary

- Upgrade mkdocs-material from >=9.5.32 to >=9.7.2 (final feature release before maintenance mode)
- Add light/dark theme toggle with OS preference detection and indigo/amber palette
- Enable modern navigation features: instant loading, breadcrumbs, back-to-top, code copy buttons, search suggestions/highlighting, header autohide, TOC scroll following
- Fix `pymdownx.tabbed` to use required `alternate_style: true`
- Fix CI workflow to actually use project `requirements.txt` via `REQUIREMENTS` env var (version pins were previously ignored in CI)
- Pin `mhausenblas/mkdocs-deploy-gh-pages` from `@master` to `@1.26`
- Update copyright year to 2026

## Test plan

- [x] Created Python venv and installed dependencies — mkdocs-material 9.7.2 and mkdocs 1.6.1 resolved correctly
- [x] `mkdocs build` succeeds with no errors
- [x] `mkdocs serve` runs and site is accessible at localhost:8000
- [x] Light/dark toggle works, both schemes render correctly
- [x] AWS logo renders acceptably on both light and dark backgrounds
- [x] Breadcrumbs, back-to-top, code copy buttons, and search features work
- [x] Custom CSS badges (rule severity levels) display correctly in both modes
- [x] Tabbed content (CDK/CF/Terraform tabs) renders with alternate style