### PR TITLE
fix: grant write permissions to docs deployment workflow

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update_docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Deploy docs


### PR DESCRIPTION
## Summary

- Add `permissions: contents: write` to the `update-docs` workflow so `GITHUB_TOKEN` can push to the `gh-pages` branch
- Without this, the deploy action fails with a 403 error when pushing the built site

## Test plan

- [ ] Merge to main and verify the `update-docs` workflow completes successfully