### PR TITLE
fix: harden GitHub Actions against script injection and pin third-party actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,20 +10,18 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-
 jobs:
   run_tests:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set release notes tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          export RELEASE_TAG_VERSION=${{ github.event.release.tag_name }}
-          echo "RELEASE_TAG_VERSION=${RELEASE_TAG_VERSION:1}" >> $GITHUB_ENV
+          echo "RELEASE_TAG_VERSION=${TAG:1}" >> $GITHUB_ENV
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - name: Check version tags
         run: make release-check
       - name: Set up Python
@@ -35,7 +33,7 @@ jobs:
         with:
           go-version: "1.24"
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v4
+        uses: terraform-linters/setup-tflint@6e87008f9dd1fe3e34e66aca6c97b4a69f72a7f4 # v4
         with:
           tflint_version: v0.61.0
       - name: Install dependencies
@@ -49,11 +47,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set release notes tag
+        env:
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          export RELEASE_TAG_VERSION=${{ github.event.release.tag_name }}
-          echo "RELEASE_TAG_VERSION=${RELEASE_TAG_VERSION:1}" >> $GITHUB_ENV
+          echo "RELEASE_TAG_VERSION=${TAG:1}" >> $GITHUB_ENV
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
@@ -65,9 +64,12 @@ jobs:
           cd cfn-lint-serverless/
           uv build
           uv publish --token ${{ secrets.PYPI_TOKEN25 }}
+
   publish_go:
     needs: run_tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go
@@ -75,7 +77,7 @@ jobs:
         with:
           go-version: "1.24"
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,10 +5,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@6db134d15f3909ccc9eefd369f02bd1e9cffdf97 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
       - name: Install ruff
         run: pip install ruff
       - name: Install dependencies
@@ -65,4 +65,3 @@ jobs:
         run: make -C $FOLDER lint
       - name: Tests
         run: make -C $FOLDER test
-


### PR DESCRIPTION
## Summary

- **Fix script injection (High)**: Replace direct `${{ github.event.release.tag_name }}` interpolation in shell `run` blocks with `env` context in `publish.yml` — prevents arbitrary command execution via crafted release tag names
- **Scope permissions (Low)**: Move `contents: write` from workflow-level to `publish_go` job-level only — `run_tests` and `publish_pypi` don't need write access
- **Add explicit permissions (Low-Medium)**: Add `permissions: contents: write` to `release-drafter.yml` instead of relying on repo default token permissions
- **Pin third-party actions to SHAs (Low)**: Pin `release-drafter/release-drafter`, `goreleaser/goreleaser-action`, `astral-sh/setup-uv`, and `terraform-linters/setup-tflint` to commit SHAs with version comments

## Test plan

- [ ] Verify `tests` workflow passes on this PR (exercises the `setup-uv` SHA pin)
- [ ] Verify `release-drafter` still creates draft releases on merge to main
- [ ] Verify next release publish completes successfully (exercises script injection fix and all SHA pins)