### PR TITLE
fix(WS2001): handle intrinsic functions in AccessLogSetting.Format

### DIFF
--- a/cfn-lint-serverless/cfn_lint_serverless/rules/api_gateway.py
+++ b/cfn-lint-serverless/cfn_lint_serverless/rules/api_gateway.py
@@ -72,7 +72,14 @@ class ApiGatewayStructuredLoggingRule(CloudFormationLintRule):
         As users can use non-string keys like '$context.integration.latency', we
         need to transform the log format into something that can be decoded into
         JSON first.
+
+        If the log format is not a string (e.g., it's an intrinsic function like
+        !Ref or !Sub), we skip validation and return True.
         """
+
+        # Skip validation when Format is an intrinsic function (Ref/Sub/etc.)
+        if not isinstance(log_format, str):
+            return True
 
         # Strip any leading/trailing quotes and whitespace that might be in the string
         log_format = log_format.strip()

--- a/cfn-lint-serverless/tests/templates/ws2001-http-sub-format.pass.yaml
+++ b/cfn-lint-serverless/tests/templates/ws2001-http-sub-format.pass.yaml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Test WS2001 when Format is !Sub for HTTP APIs
+
+Resources:
+  HttpApi:
+    Type: AWS::ApiGatewayV2::Api
+    Properties:
+      Name: test-http-api
+      ProtocolType: HTTP
+
+  HttpApiStage:
+    Type: AWS::ApiGatewayV2::Stage
+    Properties:
+      ApiId: !Ref HttpApi
+      StageName: prod
+      AutoDeploy: true
+      AccessLogSettings:
+        DestinationArn: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/apigateway/http'
+        Format: !Sub '{"requestId":"$context.requestId","ip":"$context.identity.sourceIp","requestTime":"$context.requestTime","httpMethod":"$context.httpMethod","routeKey":"$context.routeKey","status":"$context.status","protocol":"$context.protocol","responseLength":"$context.responseLength"}'
+      DefaultRouteSettings:
+        ThrottlingBurstLimit: 1000
+        ThrottlingRateLimit: 10

--- a/cfn-lint-serverless/tests/templates/ws2001-rest-ref-format.pass.yaml
+++ b/cfn-lint-serverless/tests/templates/ws2001-rest-ref-format.pass.yaml
@@ -1,0 +1,42 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Test WS2001 when Format is !Ref
+
+Parameters:
+  LogFormat:
+    Type: String
+    Default: '{"requestId":"$context.requestId"}'
+
+Resources:
+  Api:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: prod
+      AccessLogSetting:
+        DestinationArn: !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/apigateway'
+        Format: !Ref LogFormat
+      DefinitionBody:
+        openapi: "3.0.1"
+        info:
+          title: "test-api"
+          version: 1.0.0
+        paths:
+          /:
+            get:
+              responses:
+                "200":
+                  description: "OK"
+              x-amazon-apigateway-integration:
+                requestTemplates:
+                  application/json: '{"statusCode": 200}'
+                passthroughBehavior: when_no_match
+                responses:
+                  default:
+                    statusCode: "200"
+                type: mock
+      MethodSettings:
+        - HttpMethod: "*"
+          ResourcePath: "/*"
+          ThrottlingRateLimit: 10
+          ThrottlingBurstLimit: 1000
+      TracingEnabled: true


### PR DESCRIPTION
## Summary

Fixes #253

When `AccessLogSetting.Format` (REST APIs) or `AccessLogSettings.Format` (HTTP APIs) is set to an intrinsic function like `!Ref` or `!Sub`, the WS2001 rule crashes with:

```
E0002 Unknown exception while processing rule WS2001: "'dict_node' object has no attribute 'strip'"
```

**Root cause:** The `_check_log_format` method in `api_gateway.py` calls `.strip()` on line 78 without checking if the input is a string. When CloudFormation intrinsic functions are used, the value is a dict-like node (e.g., `{"Ref": "LogFormat"}`), not a string.

**Fix:** Added a type check at the start of `_check_log_format` to skip validation when the format is not a string (i.e., when it's an intrinsic function). This prevents the crash and allows templates with parameterized log formats to pass linting.

## Changes

- Added `isinstance(log_format, str)` check in `_check_log_format` method
- Added test templates for both REST APIs (`!Ref`) and HTTP APIs (`!Sub`)

## Test Plan

- [x] Reproduced the bug with the exact template from the issue
- [x] Verified fix prevents the crash
- [x] All 72 existing tests pass
- [x] New test templates added:
  - `ws2001-rest-ref-format.pass.yaml` - Tests `!Ref` with REST API
  - `ws2001-http-sub-format.pass.yaml` - Tests `!Sub` with HTTP API
- [x] `make pr` passes (linting, security, complexity checks)

**Commands run:**
```bash
# Reproduce bug (before fix)
cfn-lint template.yaml -a cfn_lint_serverless.rules
# E0002 Unknown exception while processing rule WS2001: "'dict_node' object has no attribute 'strip'"

# After fix - no errors
cfn-lint template.yaml -a cfn_lint_serverless.rules
# (no output = success)

# Run tests
pytest tests/ -v
# 72 passed

# Run PR checks
make pr
# All checks pass
```

Generated with [Claude Code](https://claude.ai/code)